### PR TITLE
Add support for Cortex-M7 r0p1 CPUs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ bit-band = []
 floating-point-unit = []
 memory-protection-unit = []
 security-extension = []
+instruction-cache = []
+data-cache = []
 
 [dependencies.drone-cortexm-macros]
 version = "=0.14.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //! | ARMv7E-M     | ARM® Cortex®-M4 r0p1   | `thumbv7em-none-eabi`       | `cortexm4_r0p1`            |
 //! | ARMv7E-M     | ARM® Cortex®-M4F r0p0  | `thumbv7em-none-eabihf`     | `cortexm4f_r0p0`           |
 //! | ARMv7E-M     | ARM® Cortex®-M4F r0p1  | `thumbv7em-none-eabihf`     | `cortexm4f_r0p1`           |
+//! | ARMv7E-M     | ARM® Cortex®-M7 r0p1   | `thumbv7em-none-eabihf`     | `cortexm7_r0p1`            |
 //! | ARMv8-M      | ARM® Cortex®-M33 r0p2  | `thumbv8m.main-none-eabi`   | `cortexm33_r0p2`           |
 //! | ARMv8-M      | ARM® Cortex®-M33 r0p3  | `thumbv8m.main-none-eabi`   | `cortexm33_r0p3`           |
 //! | ARMv8-M      | ARM® Cortex®-M33 r0p4  | `thumbv8m.main-none-eabi`   | `cortexm33_r0p4`           |

--- a/src/map/reg/scb.rs
+++ b/src/map/reg/scb.rs
@@ -128,6 +128,12 @@ reg! {
         reset => 0x0000_0200;
         traits => { RReg WReg };
         fields => {
+            /// Enables L1 instruction cache.
+            #[cfg(feature = "instruction-cache")]
+            IC => { offset => 17; width => 1; traits => { RRRegField WWRegField } };
+            /// Enables L1 data cache.
+            #[cfg(feature = "data-cache")]
+            DC => { offset => 16; width => 1; traits => { RRRegField WWRegField } };
             /// Force exception stacking start in double word aligned address.
             #[cfg(not(cortexm_core = "cortexm_r0p1"))]
             STKALIGN => { offset => 9; width => 1; traits => { RRRegField WWRegField } };

--- a/src/map/reg/scb.rs
+++ b/src/map/reg/scb.rs
@@ -129,7 +129,11 @@ reg! {
         traits => { RReg WReg };
         fields => {
             /// Force exception stacking start in double word aligned address.
+            #[cfg(not(cortexm_core = "cortexm_r0p1"))]
             STKALIGN => { offset => 9; width => 1; traits => { RRRegField WWRegField } };
+            /// Force exception stacking start in double word aligned address.
+            #[cfg(cortexm_core = "cortexm_r0p1")]
+            STKALIGN => { offset => 9; width => 1; traits => { RRRegField } };
             /// Ignore data bus fault during HardFault and NMI handlers.
             BFHFNMIGN => { offset => 8; width => 1; traits => { RRRegField WWRegField } };
             /// Trap on divide by 0.

--- a/src/reg/atomic.rs
+++ b/src/reg/atomic.rs
@@ -235,7 +235,7 @@ macro_rules! atomic_bits {
                         $strex,
                         input = in(reg) self,
                         address = in(reg) address,
-                        status = lateout(reg) status,
+                        status = out(reg) status,
                         options(nostack, preserves_flags),
                     );
                 }

--- a/src/thr/init.rs
+++ b/src/thr/init.rs
@@ -62,7 +62,10 @@ pub struct ThrInitExtended {
 #[inline]
 pub fn init_extended<T: ThrsInitToken>(_token: T) -> (T::ThrTokens, ThrInitExtended) {
     let scb_ccr = unsafe { scb::Ccr::<Srt>::take() };
+    #[cfg(not(cortexm_core = "cortexm7_r0p1"))]
     scb_ccr.store(|r| r.set_stkalign().set_nonbasethrdena());
+    #[cfg(cortexm_core = "cortexm7_r0p1")]
+    scb_ccr.store(|r| r.set_nonbasethrdena());
     let scb::Ccr {
         stkalign,
         bfhfnmign: scb_ccr_bfhfnmign,

--- a/src/thr/init.rs
+++ b/src/thr/init.rs
@@ -17,6 +17,10 @@ pub unsafe trait ThrsInitToken: Token {
 /// A set of register tokens returned by [`init_extended`].
 #[allow(missing_docs)]
 pub struct ThrInitExtended {
+    #[cfg(feature = "instruction-cache")]
+    pub scb_ccr_ic: scb::ccr::Ic<Srt>,
+    #[cfg(feature = "data-cache")]
+    pub scb_ccr_dc: scb::ccr::Dc<Srt>,
     pub scb_ccr_bfhfnmign: scb::ccr::Bfhfnmign<Srt>,
     pub scb_ccr_div_0_trp: scb::ccr::Div0Trp<Srt>,
     pub scb_ccr_unalign_trp: scb::ccr::UnalignTrp<Srt>,
@@ -67,6 +71,10 @@ pub fn init_extended<T: ThrsInitToken>(_token: T) -> (T::ThrTokens, ThrInitExten
     #[cfg(cortexm_core = "cortexm7_r0p1")]
     scb_ccr.store(|r| r.set_nonbasethrdena());
     let scb::Ccr {
+        #[cfg(feature = "instruction-cache")]
+        ic: scb_ccr_ic,
+        #[cfg(feature = "data-cache")]
+        dc: scb_ccr_dc,
         stkalign,
         bfhfnmign: scb_ccr_bfhfnmign,
         div_0_trp: scb_ccr_div_0_trp,
@@ -81,6 +89,10 @@ pub fn init_extended<T: ThrsInitToken>(_token: T) -> (T::ThrTokens, ThrInitExten
     drop(stkalign);
     drop(nonbasethrdena);
     (unsafe { T::ThrTokens::take() }, ThrInitExtended {
+        #[cfg(feature = "instruction-cache")]
+        scb_ccr_ic,
+        #[cfg(feature = "data-cache")]
+        scb_ccr_dc,
         scb_ccr_bfhfnmign,
         scb_ccr_div_0_trp,
         scb_ccr_unalign_trp,


### PR DESCRIPTION
Almost no changes to the code, only the specific bits for Cortex-M7. Also, should the register definition for SCB.CCR.STKALIGN be changed? On Cortex-M7 it's read-only unlike for other Cortex-M processors, I tried feature gating only the field but it didn't work, so I had to do the entire register block, so I only removed the line of code that sets that specific bit (for Cortex-M7 is already set).